### PR TITLE
Guard MCP-sourced responses with Bedrock guardrails

### DIFF
--- a/src/agentcore/guardrail_manager.py
+++ b/src/agentcore/guardrail_manager.py
@@ -1,22 +1,100 @@
 """Guardrail enforcement utilities for Bedrock guardrails."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 from .bedrock_clients import BedrockClientFactory
 from .config import GuardrailConfig
 
 
-@dataclass
+@dataclass(frozen=True)
+class GuardrailApplicationResult:
+    """Represents the outcome of applying a guardrail to a text payload."""
+
+    action: str
+    reason: Optional[str]
+    outputs: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def intervened(self) -> bool:
+        """Return ``True`` when the guardrail blocked or redacted content."""
+
+        return self.action.upper() == "GUARDRAIL_INTERVENED"
+
+    def resolved_text(self, original: str) -> str:
+        """Return the guardrail-adjusted text, falling back to ``original``."""
+
+        if self.outputs:
+            sanitized = "".join(self.outputs).strip()
+            if sanitized:
+                return sanitized
+        return original
+
+
+@dataclass(frozen=True)
 class GuardrailManager:
-    """Attaches guardrails to agent invocations."""
+    """Provides helpers to configure and actively enforce guardrails."""
 
     client_factory: BedrockClientFactory
     config: GuardrailConfig
 
-    def attach_to_request(self, request: Dict) -> Dict:
-        request["guardrailIdentifier"] = self.config.guardrail_arn
+    def runtime_parameters(self) -> Dict[str, str]:
+        """Return the parameters expected by ``invoke_agent``.
+
+        Keeping the method tiny avoids the indirection of mutating request
+        dictionaries in-place and makes the service layer code easier to read.
+        """
+
+        params = {"guardrailIdentifier": self.config.guardrail_arn}
         if self.config.guardrail_version:
-            request["guardrailVersion"] = self.config.guardrail_version
-        return request
+            params["guardrailVersion"] = self.config.guardrail_version
+        return params
+
+    def apply_to_output(self, content: str) -> GuardrailApplicationResult:
+        """Run ``ApplyGuardrail`` on generated content.
+
+        The Strands agent uses this to selectively evaluate MCP sourced
+        information without imposing the guardrail on trusted knowledge base
+        snippets.
+        """
+
+        client = self.client_factory.bedrock_guardrails()
+        version = self.config.guardrail_version or "DRAFT"
+        response = client.apply_guardrail(
+            guardrailIdentifier=self.config.guardrail_arn,
+            guardrailVersion=version,
+            content=[
+                {
+                    "text": {
+                        "text": content,
+                        "qualifiers": ["guard_content"],
+                    }
+                }
+            ],
+            source="OUTPUT",
+            outputScope="FULL",
+        )
+
+        outputs: List[str] = []
+        for block in response.get("outputs", []):
+            if isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str) and text:
+                    outputs.append(text)
+
+        metadata: Dict[str, Any] = {}
+        coverage = response.get("guardrailCoverage")
+        if coverage:
+            metadata["guardrailCoverage"] = coverage
+        assessments = response.get("assessments")
+        if assessments:
+            metadata["assessments"] = assessments
+
+        return GuardrailApplicationResult(
+            action=response.get("action", "NONE"),
+            reason=response.get("actionReason"),
+            outputs=outputs,
+            metadata=metadata,
+        )

--- a/src/agentcore/prompt_template_manager.py
+++ b/src/agentcore/prompt_template_manager.py
@@ -26,4 +26,5 @@ class PromptTemplateManager:
             "template": response["prompt"]
             if "prompt" in response
             else response["promptTemplate"]["textTemplate"],
+            "modelArn": response.get("modelArn"),
         }

--- a/src/agentcore/strands_agent_service.py
+++ b/src/agentcore/strands_agent_service.py
@@ -1,23 +1,75 @@
-"""Implements the Strands-powered Bedrock AgentCore runtime."""
+"""Strands Agent runtime helpers used by the Chainlit frontend."""
 from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Optional
 
 from .bedrock_clients import BedrockDependencyContainer
 from .config import AgentCoreConfig
-from .guardrail_manager import GuardrailManager
+from .guardrail_manager import GuardrailApplicationResult, GuardrailManager
 from .knowledge_base import KnowledgeBaseRetriever
 from .mcp_manager import MCPBootstrapper
 from .observability import ObservabilityManager, create_observability_manager
 from .prompt_template_manager import PromptTemplateManager
 
 try:  # pragma: no cover - illustrative import
-    from strands.agent import AgentCoreRuntime, AgentConversation
+    from strands.agent import AgentCoreRuntime
 except ImportError:  # pragma: no cover - fallback for documentation
     AgentCoreRuntime = object  # type: ignore
-    AgentConversation = dict  # type: ignore
+
+
+@dataclass(frozen=True)
+class AgentResponseMetrics:
+    """Captures latency and token usage for a model invocation."""
+
+    latency_seconds: float
+    output_tokens: int
+
+    def to_dict(self) -> Dict[str, float | int]:
+        return {
+            "latency_seconds": self.latency_seconds,
+            "output_tokens": self.output_tokens,
+        }
+
+
+@dataclass(frozen=True)
+class AgentResponse:
+    """Represents the processed output returned to the caller."""
+
+    text: str
+    citations: List[str]
+    metrics: AgentResponseMetrics
+    guardrail_action: Optional[str] = None
+    guardrail_reason: Optional[str] = None
+    guardrail_metadata: Optional[Dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class PreparedAgentRequest:
+    """A lightweight container for the runtime payload."""
+
+    input_text: str
+    prompt: str
+    session_state: Dict[str, Any]
+    citations: List[str]
+
+    def runtime_parameters(
+        self,
+        config: AgentCoreConfig,
+        conversation_id: str,
+        guardrail_params: Dict[str, str],
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "agentId": config.bedrock_agent_id,
+            "agentAliasId": config.bedrock_agent_alias_id,
+            "sessionId": conversation_id,
+            "endSession": False,
+            "inputText": self.input_text,
+            "sessionState": self.session_state,
+        }
+        params.update(guardrail_params)
+        return params
 
 
 @dataclass
@@ -34,6 +86,7 @@ class StrandsAgentService:
 
     def __post_init__(self) -> None:
         self._prompt_cache: Dict[str, str] | None = None
+        self._client_factory = self.dependencies.factory()
         self._agent_runtime = self._create_agent_runtime()
 
     def _create_agent_runtime(self) -> AgentCoreRuntime:
@@ -51,85 +104,143 @@ class StrandsAgentService:
             self._prompt_cache = self.prompt_manager.fetch()
         return self._prompt_cache
 
-    def build_agent_request(self, user_input: str) -> Tuple[Dict, List[str]]:
+    def prepare(self, user_input: str) -> PreparedAgentRequest:
         prompt_metadata = self._load_prompt()
         retrieved_docs = self.knowledge_retriever.retrieve(user_input)
         citations = self.knowledge_retriever.to_citations(retrieved_docs)
-        agent_request = {
-            "inputText": user_input,
-            "prompt": prompt_metadata["template"],
-            "sessionState": {
-                "invocationAttributes": {
-                    "knowledgeBaseConfigurations": [
-                        {
-                            "knowledgeBaseId": self.config.knowledge_base.knowledge_base_id,
-                            "modelArn": prompt_metadata.get("modelArn"),
-                        }
-                    ],
-                    "retrievedReferences": retrieved_docs,
-                }
-            },
-        }
-        agent_request = self.guardrail_manager.attach_to_request(agent_request)
-        return agent_request, citations
 
-    def invoke_prepared(self, conversation_id: str, agent_request: Dict, citations: List[str]) -> Dict:
-        start_time = time.perf_counter()
-        runtime_client = self.dependencies.factory().bedrock_agent_runtime()
-        params = {
-            "agentId": self.config.bedrock_agent_id,
-            "agentAliasId": self.config.bedrock_agent_alias_id,
-            "sessionId": conversation_id,
-            "endSession": False,
-            "inputText": agent_request["inputText"],
-            "sessionState": agent_request["sessionState"],
-            "guardrailIdentifier": agent_request["guardrailIdentifier"],
+        kb_config = {
+            "knowledgeBaseId": self.config.knowledge_base.knowledge_base_id,
         }
-        if agent_request.get("guardrailVersion"):
-            params["guardrailVersion"] = agent_request["guardrailVersion"]
+        model_arn = prompt_metadata.get("modelArn")
+        if model_arn:
+            kb_config["modelArn"] = model_arn
+
+        session_state = {
+            "invocationAttributes": {
+                "knowledgeBaseConfigurations": [kb_config],
+                "retrievedReferences": retrieved_docs,
+            }
+        }
+
+        return PreparedAgentRequest(
+            input_text=user_input,
+            prompt=prompt_metadata["template"],
+            session_state=session_state,
+            citations=citations,
+        )
+
+    def complete(self, conversation_id: str, prepared: PreparedAgentRequest) -> AgentResponse:
+        start_time = time.perf_counter()
+        runtime_client = self._client_factory.bedrock_agent_runtime()
+        params = prepared.runtime_parameters(
+            config=self.config,
+            conversation_id=conversation_id,
+            guardrail_params=self.guardrail_manager.runtime_parameters(),
+        )
         stream = runtime_client.invoke_agent(**params)
 
-        response_chunks: List[str] = []
-        total_tokens = 0
-        for event in stream.get("completion", []):
-            chunk = event.get("delta", {}).get("text", "")
-            response_chunks.append(chunk)
-            total_tokens += event.get("metrics", {}).get("outputTokens", 0)
-        response_text = "".join(response_chunks)
-
+        response_text, total_tokens, used_mcp = self._collect_response(stream)
         elapsed = time.perf_counter() - start_time
+        metrics = AgentResponseMetrics(latency_seconds=elapsed, output_tokens=total_tokens)
+
+        guardrail_result: Optional[GuardrailApplicationResult] = None
+        if used_mcp and response_text:
+            guardrail_result = self.guardrail_manager.apply_to_output(response_text)
+            if guardrail_result.intervened:
+                response_text = guardrail_result.resolved_text(
+                    "⚠️ Guardrail prevented sharing unsafe MCP-sourced content."
+                )
+
         if self.observability:
             self.observability.emit_metrics(
                 {
-                    "LatencyMs": elapsed * 1000,
-                    "OutputTokens": float(total_tokens),
+                    "LatencyMs": metrics.latency_seconds * 1000,
+                    "OutputTokens": float(metrics.output_tokens),
                 }
             )
             self.observability.add_properties({"agentId": self.config.bedrock_agent_id})
 
-        return {
-            "response": response_text,
-            "citations": citations,
-            "metrics": {"latency_seconds": elapsed, "output_tokens": total_tokens},
-        }
+        return AgentResponse(
+            text=response_text,
+            citations=prepared.citations,
+            metrics=metrics,
+            guardrail_action=guardrail_result.action if guardrail_result else None,
+            guardrail_reason=guardrail_result.reason if guardrail_result else None,
+            guardrail_metadata=guardrail_result.metadata if guardrail_result and guardrail_result.metadata else None,
+        )
 
-    def invoke(self, conversation_id: str, user_input: str) -> Dict:
-        agent_request, citations = self.build_agent_request(user_input)
-        return self.invoke_prepared(conversation_id, agent_request, citations)
+    def respond(self, conversation_id: str, user_input: str) -> AgentResponse:
+        prepared = self.prepare(user_input)
+        return self.complete(conversation_id, prepared)
+
+    @staticmethod
+    def _collect_response(stream: Dict[str, Any]) -> tuple[str, int, bool]:
+        response_chunks: List[str] = []
+        total_tokens = 0
+        for event in stream.get("completion", []):
+            chunk = event.get("delta", {}).get("text", "")
+            if chunk:
+                response_chunks.append(chunk)
+            metrics = event.get("metrics", {})
+            if metrics:
+                total_tokens += int(metrics.get("outputTokens", 0))
+        used_mcp = StrandsAgentService._detect_mcp_usage(stream)
+        return "".join(response_chunks), total_tokens, used_mcp
+
+    @staticmethod
+    def _contains_keyword(payload: Any, keywords: set[str]) -> bool:
+        if isinstance(payload, str):
+            lowered = payload.lower()
+            return any(keyword in lowered for keyword in keywords)
+        if isinstance(payload, dict):
+            return any(
+                StrandsAgentService._contains_keyword(key, keywords)
+                or StrandsAgentService._contains_keyword(value, keywords)
+                for key, value in payload.items()
+            )
+        if isinstance(payload, list):
+            return any(StrandsAgentService._contains_keyword(item, keywords) for item in payload)
+        return False
+
+    @staticmethod
+    def _detect_mcp_usage(stream: Dict[str, Any]) -> bool:
+        """Detect whether the agent trace includes MCP sourced content."""
+
+        keywords = {"mcp://", "model context protocol", "mcp"}
+        trace_events = stream.get("trace", [])
+        for event in trace_events:
+            if not isinstance(event, dict):
+                continue
+            detail = event.get("trace", event)
+            if isinstance(detail, dict):
+                type_hint = str(detail.get("type", "")).upper()
+                if type_hint in {"ACTION_GROUP", "TOOL", "MCP"}:
+                    return True
+                provider = detail.get("provider")
+                if isinstance(provider, str) and "mcp" in provider.lower():
+                    return True
+                metadata = detail.get("observationMetadata") or detail.get("metadata")
+                if StrandsAgentService._contains_keyword(metadata, keywords):
+                    return True
+            if StrandsAgentService._contains_keyword(event, keywords):
+                return True
+        return StrandsAgentService._contains_keyword(stream, keywords)
 
     @classmethod
     def create(cls, dependencies: BedrockDependencyContainer, install_dir: str = "/opt/mcp") -> "StrandsAgentService":
         config = dependencies.config
+        factory = dependencies.factory()
         prompt_manager = PromptTemplateManager(
-            client_factory=dependencies.factory(),
+            client_factory=factory,
             config=config.prompt_template,
         )
         guardrail_manager = GuardrailManager(
-            client_factory=dependencies.factory(),
+            client_factory=factory,
             config=config.guardrail,
         )
         knowledge_retriever = KnowledgeBaseRetriever(
-            client_factory=dependencies.factory(),
+            client_factory=factory,
             config=config.knowledge_base,
         )
         observability = create_observability_manager(config)


### PR DESCRIPTION
## Summary
- add a `GuardrailApplicationResult` helper and wire `GuardrailManager` to call `ApplyGuardrail` against generated text so trusted knowledge-base snippets stay unfiltered
- detect Model Context Protocol usage in `StrandsAgentService`, re-run MCP answers through the guardrail, and return guardrail metadata with the agent response
- surface guardrail activity in the Chainlit UI by enriching the invocation metrics pane and final response message

## Testing
- python -m compileall src/chainlit_frontend src/agentcore

------
https://chatgpt.com/codex/tasks/task_e_68ccf3fba9e4832d9cace83fc797f608